### PR TITLE
Issue #9 - use prettier --check over prettylint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+content
 public/css/main.css
 public/js/main.js
 package-lock.json

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "npm run test:eslint && npm run test:stylelint && npm run test:prettier",
     "test:eslint": "eslint config.js theme/js/**.js",
     "test:stylelint": "stylelint theme/less/**.less",
-    "test:prettier": "prettylint pages/**.html pages/**.md",
+    "test:prettier": "prettier --check pages/**.html pages/**.md",
     "build": "cmints --static",
     "deploy": "cmints --static --deploy",
     "start": "cmints --start",
@@ -28,7 +28,6 @@
   "devDependencies": {
     "eslint": "^6.8.0",
     "prettier": "^2.0.5",
-    "prettylint": "^1.0.0",
     "stylelint": "^13.6.1",
     "stylelint-config-recommended": "^3.0.0"
   }


### PR DESCRIPTION
## Background

See -> https://github.com/Privacy-Managers/privacy-manager-website/issues/9 

## What is included

Seems like prettier support [`--check` flag for linting](https://prettier.io/docs/en/cli.html#--check) which we might want to use over prettylint and dropping the dependency.